### PR TITLE
Reubicacion y rediseño de relacionados

### DIFF
--- a/src/components/pageProps/productDetails/ProductsOnSale.js
+++ b/src/components/pageProps/productDetails/ProductsOnSale.js
@@ -25,19 +25,20 @@ const ProductsOnSale = () => {
   return (
     <div className="mt-8">
       <Heading heading="Productos Relacionados" />
-      <div className="flex flex-wrap justify-center gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6 place-items-center">
         {randomProducts.map((item) => (
-          <Product
-            key={item.id}
-            _id={item.id}
-            img={item.imagenes || "/no-photo.jpg"}
-            productName={item.nombre}
-            price={item.precio}
-            color={item.color}
-            badge={true}
-            des={item.descripcion || "Sin descripción disponible."}
-            tallas={item.tallas}
-          />
+          <div key={item.id} className="w-full max-w-80">
+            <Product
+              _id={item.id}
+              img={item.imagenes || "/no-photo.jpg"}
+              productName={item.nombre}
+              price={item.precio}
+              color={item.color}
+              badge={true}
+              des={item.descripcion || "Sin descripción disponible."}
+              tallas={item.tallas}
+            />
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/pageProps/productDetails/ProductsOnSale.js
+++ b/src/components/pageProps/productDetails/ProductsOnSale.js
@@ -1,7 +1,8 @@
 import React from "react"; 
 import { useProducts } from "../../services/productsContext";
 import { CircularProgress } from "@mui/material";
-import { formatMoney } from "../../services/utils";
+import Heading from "../../home/Products/Heading";
+import Product from "../../home/Products/Product";
 
 const ProductsOnSale = () => {
   const { productos, loading } = useProducts();
@@ -11,7 +12,7 @@ const ProductsOnSale = () => {
     const shuffled = Array.from(array).sort(() => Math.random() - 0.5);
     return shuffled.slice(0, num);
   };
-  const randomProducts = getRandomProducts(productos, 5);
+  const randomProducts = getRandomProducts(productos, 4);
 
   if (loading) {
     return (
@@ -22,26 +23,21 @@ const ProductsOnSale = () => {
   }
 
   return (
-    <div>
-      <h3 className="font-titleFont text-xl font-semibold mb-6 underline underline-offset-4 decoration-[1px] text-center">
-        Productos Relacionados
-      </h3>
-      <div className="mx-auto w-fit flex flex-col gap-2">
+    <div className="mt-8">
+      <Heading heading="Productos Relacionados" />
+      <div className="flex flex-wrap justify-center gap-6">
         {randomProducts.map((item) => (
-          <div
-            key={item._id}
-            className="flex items-center gap-4 border-b-[1px] border-b-gray-300 py-2"
-          >
-            <img
-              className="w-24 h-24"
-              src={item.imagenes?.[0] || "/no-photo.jpg"}
-              alt={item.nombre}
-            />
-            <div className="flex flex-col gap-2 font-titleFont">
-              <p className="text-base font-medium">{item.nombre}</p>
-              <p className="text-sm font-semibold">{formatMoney(item.precio)}</p>
-            </div>
-          </div>
+          <Product
+            key={item.id}
+            _id={item.id}
+            img={item.imagenes || "/no-photo.jpg"}
+            productName={item.nombre}
+            price={item.precio}
+            color={item.color}
+            badge={true}
+            des={item.descripcion || "Sin descripción disponible."}
+            tallas={item.tallas}
+          />
         ))}
       </div>
     </div>

--- a/src/pages/ProductDetails/ProductDetails.js
+++ b/src/pages/ProductDetails/ProductDetails.js
@@ -99,10 +99,7 @@ const ProductDetails = () => {
         <div className="xl:-mt-10 -mt-7">
           <Breadcrumbs title="" prevLocation={prevLocation} />
         </div>
-        <div className="w-full grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-4 -mt-5 xl:-mt-8 pb-10 bg-gray-100 p-4">
-          <div className="order-3 xl:order-1">
-            <MemoizedProductsOnSale />
-          </div>
+        <div className="w-full grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4 -mt-5 xl:-mt-8 pb-10 bg-gray-100 p-4">
 
           <div className="xl:col-span-2 relative group order-1 xl:order-2 flex items-center">
             <div className="relative w-full overflow-hidden min-h-[300px] h-[70vh]">
@@ -152,6 +149,7 @@ const ProductDetails = () => {
             <ProductInfo productInfo={productInfo} />
           </div>
         </div>
+        <MemoizedProductsOnSale />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- move related products under main item view
- redesign related products to show horizontal product cards

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0e6188e883239443bbaa9bf6ff6b